### PR TITLE
Issue7

### DIFF
--- a/src/component/home/search/Button/Button.tsx
+++ b/src/component/home/search/Button/Button.tsx
@@ -18,20 +18,18 @@ interface IImageStyle {
 
 const SearchButton = (props: IProps) => {
   const { status, imageStyle, onClickHandler, inputRef } = props;
-  console.log(status);
   const imageSrc = imageStyle?.src ?? plane2;
   const [dot, setDot] = useState<string>("");
-  useEffect(() => {
-    if (status === "isLoading") {
-      const intervalId = setInterval(() => {
-        setDot((prevDot) => (prevDot.length < 3 ? dot + "." : "."));
-      }, 500);
 
-      return () => {
-        clearInterval(intervalId);
-      };
-    }
-  }, [status, dot]);
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setDot((prevDot) => (prevDot.length < 3 ? dot + "." : "."));
+    }, 500); //props
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [status === "isLoading" && dot]);
 
   if (status === "isSuccess" || status === "Idle") {
     return (

--- a/src/component/home/searchResult/New/NewSearch.tsx
+++ b/src/component/home/searchResult/New/NewSearch.tsx
@@ -1,32 +1,28 @@
+import Image from "next/image";
+import Capabilities from "@/asset/Capabilities.svg";
+import Limitations from "@/asset/Limitations.svg";
+import { IMockData } from "@/utils/types/Types";
+import Examples from "@/asset/Examples.svg";
 import {
+  ChatGPT,
+  Item,
   InfoBox,
   InfoCategory,
   Category,
   ItemBox,
-  Item,
-  ChatGPT,
 } from "./NewSearch.styles";
-import Image from "next/image";
-import Capabilities from "@/asset/Capabilities.svg";
-import Limitations from "@/asset/Limitations.svg";
-import Examples from "@/asset/Examples.svg";
-
 interface IProps<T> {
   storybookProps: T;
 }
-interface IMockData<T> {
-  categories: string[];
-  categoriesImg: any[];
-  categoriesData: T;
-}
+
 interface ICategoiesData {
   [category: string]: string[];
 }
 
-const mockData: IMockData<ICategoiesData> = {
-  categories: ["Examples", "Capabilities", "Limitations"],
+const mockData: IMockData<Record<string, any>> = {
+  categoriesData: ["Examples", "Capabilities", "Limitations"],
   categoriesImg: [Examples, Capabilities, Limitations],
-  categoriesData: {
+  categoriesDetail: {
     Examples: [...EXAMPLES],
     Capabilities: [...CAPABILITIES],
     Limitations: [...LIMITATIONS],
@@ -38,8 +34,8 @@ const NewSearch = (props: IProps<IMockData<ICategoiesData>>) => {
   const { storybookProps = mockData } = props;
 
   const categoryDetails = (category: string) => {
-    const { categoriesData } = storybookProps;
-    const data = categoriesData[category];
+    const { categoriesDetail } = storybookProps;
+    const data = categoriesDetail[category];
 
     if (!data) {
       return <Item>No data available for this category</Item>;
@@ -53,7 +49,7 @@ const NewSearch = (props: IProps<IMockData<ICategoiesData>>) => {
     <>
       <ChatGPT>Chat GPT</ChatGPT>
       <InfoBox>
-        {storybookProps.categories.map((category: string, idx: number) => {
+        {storybookProps.categoriesData.map((category: string, idx: number) => {
           return (
             <InfoCategory key={idx}>
               <Image alt={category} src={mockData.categoriesImg[idx]}></Image>

--- a/src/component/sidebar/options/OptionBox.tsx
+++ b/src/component/sidebar/options/OptionBox.tsx
@@ -26,14 +26,14 @@ const mockData: IMockData<IOptionsData> = {
 const OptionBox = (props: any) => {
   const { storybookProps = mockData } = props;
 
-  const { options, optionsImg, optionsData } = storybookProps;
+  const { optionsData, optionsImg, optionsDetail } = storybookProps;
 
   return (
     <>
-      {options.map((option: string, index: number) => (
+      {optionsData.map((option: string, index: number) => (
         <Option key={option}>
           <Image alt={option} src={optionsImg[index]} />
-          {optionsData[option]}
+          {optionsDetail[option]}
         </Option>
       ))}
     </>

--- a/src/component/sidebar/options/OptionBox.tsx
+++ b/src/component/sidebar/options/OptionBox.tsx
@@ -6,23 +6,15 @@ import Update from "@/asset/Update.svg";
 import Logout from "@/asset/Logout.svg";
 import Light from "@/asset/Light.svg";
 import { OPTIONS } from "@/constant/sideBarOption";
-
-interface IProps<T> {
-  storybookProps: T;
-}
-interface IMockData<T> {
-  options: string[];
-  optionsImg: any[];
-  optionsData: T;
-}
+import { IMockData } from "@/utils/types/Types";
 interface IOptionsData {
   [key: string]: string;
 }
 
 const mockData: IMockData<IOptionsData> = {
-  options: ["Clear", "Light", "Upgrade", "Update", "Logout"],
+  optionsData: ["Clear", "Light", "Upgrade", "Update", "Logout"],
   optionsImg: [Clear, Light, Upgrade, Update, Logout],
-  optionsData: {
+  optionsDetail: {
     Clear: OPTIONS.CLEAR,
     Upgrade: OPTIONS.UPGRADE,
     Update: OPTIONS.UPDATE,
@@ -30,6 +22,7 @@ const mockData: IMockData<IOptionsData> = {
     Light: OPTIONS.LIGHT,
   },
 };
+
 const OptionBox = (props: any) => {
   const { storybookProps = mockData } = props;
 

--- a/src/utils/types/Types.tsx
+++ b/src/utils/types/Types.tsx
@@ -1,0 +1,10 @@
+/* storybook mockData */
+type Data<T extends string> = `${T}Data`;
+type Img<T extends string> = `${T}Img`;
+type Detail<T extends string> = `${T}Detail`;
+
+export type IMockData<T> = {
+  [key: Data<string>]: string[];
+  [key: Img<string>]: string[];
+  [key: Detail<string>]: T;
+};


### PR DESCRIPTION
### useEffect 의존성 배열 수정

#8 
수정하게 된 이유
1.  현재 컴포넌트 구조상 useEffect 외부에서 if문으로 감쌀수 없는 상태기 때문에 둘 다 동일하게 컴포넌트가 처음 렌더링될때, useEffect는 실행되기 때문에 성능상으로 똑같습니다.
2. 그렇다면 , useEffect가 콜백함수를 실행하는 조건을 비교 해봤을 때, dot이 업데이트 되는 경우가 있다고 한다면, 저의 의도와는 다르게 동작하는거기때문에 기존것으로 롤백했습니다.

### type 추가

여러 컴포넌트에서 IMockData 라는 형식을 반복해서 사용하고 있었기 때문에 공통된 Type을 설정해주었습니다.
